### PR TITLE
Separate changes list from preceding paragraph to correct markdown markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ CAROS 16.02
 ===========
 
 Upgrade note (for building brands):
+
 	* bitbake -c cleanall opkg opkg-native
 	  opkg changed the way packages are checksummed
 	* fixes from poky upstream:


### PR DESCRIPTION
Right now, description of 16.02 [is a mess](https://allmychanges.com/p/os/caros/).

After this fix, markdown will be rendered correctly.
