### PR TITLE
Output BUILD_ID in "Build Configuration:" overview

### DIFF
--- a/caros-16.04-lamobo-r1.xml
+++ b/caros-16.04-lamobo-r1.xml
@@ -36,6 +36,8 @@
 
 	<local_conf>
 		<![CDATA[
+BUILDCFG_VARS_append = " BUILD_ID"
+
 MACHINE = "sun7i-a20-lamobo-r1"
 DISTRO = "caros"
 DL_DIR = "/REDO/download"

--- a/caros-16.04-vmware.xml
+++ b/caros-16.04-vmware.xml
@@ -36,6 +36,8 @@
 
 	<local_conf>
 		<![CDATA[
+BUILDCFG_VARS_append = " BUILD_ID"
+
 MACHINE = "vmware"
 DISTRO = "caros"
 DL_DIR = "/REDO/download"


### PR DESCRIPTION
Adds the BUILD_ID to the output shown above the current build steps.

Before:

```
Build Configuration:
BB_VERSION        = "1.28.0"
BUILD_SYS         = "x86_64-linux"
NATIVELSBSTRING   = "Ubuntu-14.04"
TARGET_SYS        = "x86_64-tposs-linux"
MACHINE           = "vmware"
DISTRO            = "caros"
DISTRO_VERSION    = "16.04"
TUNE_FEATURES     = "m64 core2"
TARGET_FPU        = ""
```

After:

```
Build Configuration:
BB_VERSION        = "1.28.0"
BUILD_SYS         = "x86_64-linux"
NATIVELSBSTRING   = "Ubuntu-14.04"
TARGET_SYS        = "x86_64-tposs-linux"
MACHINE           = "vmware"
DISTRO            = "caros"
DISTRO_VERSION    = "16.04"
TUNE_FEATURES     = "m64 core2"
TARGET_FPU        = ""
BUILD_ID          = "1235"
```

modified:   caros-16.04-lamobo-r1.xml
modified:   caros-16.04-vmware.xml
